### PR TITLE
Updating version to 1.16.4 and fixing class/method not found issues

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,19 +2,19 @@
 org.gradle.jvmargs=-Xmx1G
 
 # Fabric
-minecraft_version = 1.16.1
-yarn_mappings = 1.16.1+build.21
+minecraft_version = 1.16.4
+yarn_mappings = 1.16.4+build.9
 tiny_version = v2
-loader_version = 0.9.0+build.204
+loader_version = 0.10.8
 
 # Fabric API
-api_version = 0.16.0+build.384-1.16.1
+api_version = 0.26.0+1.16
 
 # Mod
-mod_version = 1.3.0
+mod_version = 1.4.0
 mod_group = com.shnupbups
 mod_name = redstone-bits
-version_meta = fabric-1.16.1
+version_meta = fabric-1.16.4
 
 # Conveniences
 rei_version = 4.10.3

--- a/src/main/java/com/shnupbups/redstonebits/FakePlayerEntity.java
+++ b/src/main/java/com/shnupbups/redstonebits/FakePlayerEntity.java
@@ -15,7 +15,7 @@ public class FakePlayerEntity extends PlayerEntity {
 	public static final GameProfile profile = new GameProfile(uuid, name);
 	
 	public FakePlayerEntity(World world, ItemStack heldStack) {
-		super(world, new BlockPos(0, 0, 0), profile);
+		super(world, new BlockPos(0, 0, 0), 0.0f,  profile);
 		this.setStackInHand(Hand.MAIN_HAND, heldStack);
 	}
 	

--- a/src/main/java/com/shnupbups/redstonebits/ModBlocks.java
+++ b/src/main/java/com/shnupbups/redstonebits/ModBlocks.java
@@ -22,7 +22,7 @@ public class ModBlocks {
 	public static final Block CHECKER = register("checker", new CheckerBlock(Block.Settings.copy(Blocks.OBSERVER)));
 	public static final Block COUNTER = register("counter", new CounterBlock(Block.Settings.copy(Blocks.REPEATER)));
 	public static final Block RESISTOR = register("resistor", new ResistorBlock(Block.Settings.copy(Blocks.REPEATER)));
-	public static final Block ANALOG_REDSTONE_LAMP = register("analog_redstone_lamp", new AnalogRedstoneLampBlock(Block.Settings.copy(Blocks.REDSTONE_LAMP).lightLevel((state) -> state.get(AnalogRedstoneLampBlock.POWER))));
+	public static final Block ANALOG_REDSTONE_LAMP = register("analog_redstone_lamp", new AnalogRedstoneLampBlock(Block.Settings.copy(Blocks.REDSTONE_LAMP).luminance((state) -> state.get(AnalogRedstoneLampBlock.POWER))));
 	
 	public static <T extends Block> T register(String name, T block) {
 		T b = Registry.register(Registry.BLOCK, RedstoneBits.id(name), block);

--- a/src/main/resources/data/redstonebits/recipes/analog_redstone_lamp.json
+++ b/src/main/resources/data/redstonebits/recipes/analog_redstone_lamp.json
@@ -1,7 +1,7 @@
 {
   "type": "minecraft:crafting_shaped",
   "pattern": [
-    " R",
+    " R ",
     "RGR",
     " Q "
   ],


### PR DESCRIPTION
Updating version to 1.16.4 and fixing class/method not found issues with breaker and redstone lamp, as well as fixing redstone lamp recipe fixes https://github.com/Shnupbups/redstone-bits/issues/9 and fixes https://github.com/Shnupbups/redstone-bits/issues/8