### PR TITLE
Fix block breaker crash on teleport by checking if block is air or null

### DIFF
--- a/src/main/java/com/shnupbups/redstonebits/block/BreakerBlock.java
+++ b/src/main/java/com/shnupbups/redstonebits/block/BreakerBlock.java
@@ -119,8 +119,11 @@ public class BreakerBlock extends BlockWithEntity implements BlockEntityProvider
 	public boolean startBreak(World world, BlockPos pos) {
 		BlockEntity be = world.getBlockEntity(pos);
 		BlockState state = world.getBlockState(pos);
+		if(state.isAir()) {
+			return false;
+		}
 		BlockState breakState = world.getBlockState(pos.add(state.get(FACING).getVector()));
-		boolean isBreakable = !(breakState.isAir() || breakState.getHardness(world, pos) < 0);
+		boolean isBreakable = !(breakState.getHardness(world, pos) < 0);
 		if (be instanceof BreakerBlockEntity && isBreakable) {
 			((BreakerBlockEntity) be).startBreak();
 		}

--- a/src/main/java/com/shnupbups/redstonebits/blockentity/BreakerBlockEntity.java
+++ b/src/main/java/com/shnupbups/redstonebits/blockentity/BreakerBlockEntity.java
@@ -50,6 +50,9 @@ public class BreakerBlockEntity extends LockableContainerBlockEntity {
 
 	@Environment(EnvType.CLIENT)
 	public static void clientTick(World world, BlockPos pos, BlockState state, BreakerBlockEntity blockEntity) {
+		if(blockEntity.getBreakState() == null || blockEntity.getBreakState().isAir()) {
+			return;
+		}
 		if (blockEntity.isBreaking()) {
 			//System.out.println("breaking! time: " + blockEntity.getBreakTime() + " progress: " + blockEntity.getBreakProgress() + " percent: " + blockEntity.getBreakPercentage() + "%");
 			world.setBlockBreakingInfo(blockEntity.getFakePlayer().getId(), blockEntity.getBreakPos(), blockEntity.getBreakPercentage() / 10);


### PR DESCRIPTION
Fix block breaker crash on teleport by checking if block is air or null before using the FACING property.
Resolves issue #17, more specifically @Raidobw2's comment.
Tested on dev run config as well as in a release JAR.

Steps to reproduce original issue:
1. Create a world, cheats enabled.
2. Place down a blocker and a block in front of it.
3. /tp @p 500 128 500 (far enough away that the chunk becomes unloaded)
This should cause a client-side crash.